### PR TITLE
Revert "Update eslint to version 3.0.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "coveralls": "^2.11.4",
-    "eslint": "^3.0.0",
+    "eslint": "^2.10.1",
     "eslint-config-xo-space": "^0.14.0",
     "istanbul": "^0.4.0",
     "mocha": "^2.3.3",


### PR DESCRIPTION
Reverts htanjo/replocal#4 because ESLint 3.0 doesn't work on Node.js 0.12
